### PR TITLE
Convert ffi-ncurses(2) dependency to the standard curses library

### DIFF
--- a/multi_progress_bar2.gemspec
+++ b/multi_progress_bar2.gemspec
@@ -7,11 +7,11 @@ Gem::Specification.new do |s|
   s.date = "2018-04-02"
   s.version = MultiProgressBar::VERSION
   s.summary = "Displays multiple progress bars using Ncurses."
-  s.description  = "Fork of multi_progress_bar, using the (fixed) `ffi-ncurses2` instead of the defunct `ncurses`"
+  s.description  = "Fork of multi_progress_bar, using `curses` instead of the defunct `ncurses`"
   s.email = "peter.a.jaros@gmail.com"
   s.homepage = "http://github.com/Peeja/multi_progress_bar/tree/master/"
   s.authors = ["Peter Jaros"]
 
-  s.add_dependency "ffi-ncurses2", "~> 0.4.1"
+  s.add_dependency "curses", "~> 1.2.4"
   s.add_dependency "ruby-progressbar", "0.0.9"
 end


### PR DESCRIPTION
ffi-ncurses is now abandoned, while curses is standard/maintained.

Closes #6.